### PR TITLE
feat(shop): catalog, product pages, and search improvements

### DIFF
--- a/app/Domain/Product/Queries/ProductListingQuery.php
+++ b/app/Domain/Product/Queries/ProductListingQuery.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Product\Queries;
+
+use App\Models\Minifig;
+use App\Models\Part;
+use App\Models\Product;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * Shared eager-load strategy for Product + morph productable trees used by
+ * catalog, product suggestions, set BOMs, and search hydration.
+ */
+final class ProductListingQuery
+{
+    /**
+     * @return Builder<Product>
+     */
+    public static function base(): Builder
+    {
+        return Product::query()->with(self::defaultWith());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function defaultWith(): array
+    {
+        return [
+            'color',
+            'productable' => fn (MorphTo $morphTo) => $morphTo->morphWith([
+                Part::class => ['partColors.media', 'partCategory', 'products.color'],
+                Minifig::class => ['media'],
+            ]),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function forType(string $type): array
+    {
+        if ($type === 'minifig') {
+            return [
+                'color',
+                'productable' => fn (MorphTo $morphTo) => $morphTo->morphWith([
+                    Minifig::class => ['media'],
+                ]),
+            ];
+        }
+
+        return [
+            'color',
+            'productable' => fn (MorphTo $morphTo) => $morphTo->morphWith([
+                Part::class => ['partColors.media', 'partCategory', 'products.color'],
+            ]),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -5,36 +5,76 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Minifig\MinifigSearchResource;
 use App\Http\Resources\Product\ProductSearchResource;
 use App\Http\Resources\Set\SetSearchResource;
+use App\Models\Minifig;
+use App\Models\Part;
 use App\Models\Product;
 use App\Models\Set;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class SearchController extends Controller
 {
     /**
-     * Search products and sets via Scout (Typesense) and return combined results.
+     * Search parts (as products), minifigs, and sets via Scout and return
+     * combined results.
      *
-     * Products are collapsed by part (one card per part, all colors merged).
-     * Sets are returned directly, ordered by relevance.
+     * Part products are collapsed by part (one card per part, colors merged).
+     * Minifigs are returned from the Minifig index. Sets are returned directly.
      */
     public function __invoke(Request $request): JsonResponse
     {
         $query = trim((string) $request->query('q', ''));
 
         if ($query === '') {
-            return response()->json(['data' => ['products' => [], 'sets' => []]]);
+            return response()->json([
+                'data' => [
+                    'products' => [],
+                    'minifigs' => [],
+                    'sets' => [],
+                ],
+            ]);
         }
 
-        $products = Product::search($query)
-            ->take(100)
-            ->get();
+        $partMorph = (new Part)->getMorphClass();
+        $builder = Product::search($query);
 
-        $uniqueProducts = $products
+        // Typesense/Meilisearch/Algolia can filter on the indexed `type` field.
+        // Collection/database engines apply where() as SQL against products and
+        // have no `type` column, so they fall through to the PHP filter below.
+        if (! in_array(config('scout.driver'), ['collection', 'database', 'null'], true)) {
+            $builder->where('type', 'part');
+        }
+
+        $products = $builder
+            ->take(100)
+            ->get()
+            ->filter(fn (Product $product): bool => $product->productable_type === $partMorph && $product->stock > 0)
             ->unique(fn (Product $product): string => "{$product->productable_type}_{$product->productable_id}")
-            ->load('productable.partColors.media', 'productable.products');
+            ->values()
+            ->load([
+                'color',
+                'productable' => fn (MorphTo $morphTo) => $morphTo->morphWith([
+                    Part::class => ['partColors.media', 'products.color'],
+                ]),
+            ]);
+
+        $minifigs = Minifig::search($query)
+            ->take(40)
+            ->get()
+            ->load(['media', 'products'])
+            ->filter(function (Minifig $minifig): bool {
+                // Keep catalog-only minifigs; hide ones that only have zero-stock products.
+                if ($minifig->products->isEmpty()) {
+                    return true;
+                }
+
+                return $minifig->products->contains(fn (Product $product): bool => $product->stock > 0);
+            })
+            ->values();
 
         $sets = Set::search($query)
             ->take(20)
@@ -43,8 +83,18 @@ class SearchController extends Controller
 
         return response()->json([
             'data' => [
-                'products' => $uniqueProducts->map(fn (Product $product): array => (new ProductSearchResource($product))->resolve())->values(),
-                'sets' => $sets->map(fn (Set $set): array => (new SetSearchResource($set))->resolve())->values(),
+                'products' => $products
+                    ->map(fn (Product $product): array => (new ProductSearchResource($product))->resolve())
+                    ->values()
+                    ->all(),
+                'minifigs' => $minifigs
+                    ->map(fn (Minifig $minifig): array => (new MinifigSearchResource($minifig))->resolve())
+                    ->values()
+                    ->all(),
+                'sets' => $sets
+                    ->map(fn (Set $set): array => (new SetSearchResource($set))->resolve())
+                    ->values()
+                    ->all(),
             ],
         ]);
     }

--- a/app/Http/Controllers/CatalogController.php
+++ b/app/Http/Controllers/CatalogController.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Domain\Product\Queries\ProductListingQuery;
+use App\Http\Resources\Product\ProductResource;
+use App\Models\Color;
+use App\Models\Minifig;
+use App\Models\Part;
+use App\Models\PartCategory;
+use App\Models\Product;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Inertia\Response;
+
+class CatalogController extends Controller
+{
+    public function parts(Request $request): Response
+    {
+        return $this->listing($request, type: 'part');
+    }
+
+    public function minifigs(Request $request): Response
+    {
+        return $this->listing($request, type: 'minifig');
+    }
+
+    public function search(Request $request): Response
+    {
+        $q = trim((string) $request->query('q', ''));
+        $categoryId = $request->integer('category_id') ?: null;
+        $colorId = $request->integer('color_id') ?: null;
+
+        $query = Product::query()
+            ->with(ProductListingQuery::defaultWith())
+            ->where('stock', '>', 0)
+            ->when($colorId, fn (Builder $builder) => $builder->where('color_id', $colorId))
+            ->when($categoryId, function (Builder $builder) use ($categoryId): void {
+                $builder->whereHasMorph(
+                    'productable',
+                    [Part::class],
+                    fn (Builder $part) => $part->where('part_category_id', $categoryId),
+                );
+            })
+            ->when($q !== '', function (Builder $builder) use ($q): void {
+                $builder->where(function (Builder $inner) use ($q): void {
+                    $inner->whereHasMorph(
+                        'productable',
+                        [Part::class, Minifig::class],
+                        function (Builder $productable) use ($q): void {
+                            $productable->where(function (Builder $match) use ($q): void {
+                                $match
+                                    ->where('name', 'like', "%{$q}%")
+                                    ->orWhere('bricklink_id', 'like', "%{$q}%");
+                            });
+                        },
+                    );
+                });
+            })
+            ->orderByDesc('stock');
+
+        $products = $query->paginate(48)->withQueryString();
+
+        return inertia('shop/catalog', [
+            'title' => $q !== '' ? "Zoekresultaten voor “{$q}”" : 'Zoeken',
+            'type' => 'search',
+            'query' => $q,
+            'products' => ProductResource::collection($products),
+            'filters' => [
+                'categories' => PartCategory::query()->orderBy('name')->get(['id', 'name']),
+                'colors' => Color::query()
+                    ->where('bricklink_color_id', '!=', '0')
+                    ->orderBy('name')
+                    ->limit(80)
+                    ->get(['id', 'name', 'hex']),
+            ],
+            'active' => [
+                'category_id' => $categoryId,
+                'color_id' => $colorId,
+                'q' => $q,
+            ],
+        ]);
+    }
+
+    protected function listing(Request $request, string $type): Response
+    {
+        $morph = $type === 'minifig' ? Minifig::class : Part::class;
+        $categoryId = $request->integer('category_id') ?: null;
+        $colorId = $request->integer('color_id') ?: null;
+
+        $query = Product::query()
+            ->with(ProductListingQuery::forType($type))
+            ->where('productable_type', (new $morph)->getMorphClass())
+            ->where('stock', '>', 0)
+            ->when($colorId, fn ($q) => $q->where('color_id', $colorId))
+            ->when($categoryId && $type === 'part', function ($q) use ($categoryId): void {
+                $q->whereHasMorph('productable', [Part::class], fn ($p) => $p->where('part_category_id', $categoryId));
+            })
+            ->orderByDesc('stock');
+
+        $products = $query->paginate(48)->withQueryString();
+
+        return inertia('shop/catalog', [
+            'title' => $type === 'minifig' ? 'Minifiguren' : 'Onderdelen',
+            'type' => $type,
+            'query' => null,
+            'products' => ProductResource::collection($products),
+            'filters' => [
+                'categories' => $type === 'part'
+                    ? PartCategory::query()->orderBy('name')->get(['id', 'name'])
+                    : [],
+                'colors' => $type === 'part'
+                    ? Color::query()
+                        ->where('bricklink_color_id', '!=', '0')
+                        ->whereHas('products', fn ($p) => $p->where('stock', '>', 0)->where('productable_type', (new Part)->getMorphClass()))
+                        ->orderBy('name')
+                        ->limit(80)
+                        ->get(['id', 'name', 'hex'])
+                    : [],
+            ],
+            'active' => [
+                'category_id' => $categoryId,
+                'color_id' => $colorId,
+                'q' => null,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Domain\Product\Queries\ProductListingQuery;
 use App\Http\Resources\Product\ProductResource;
+use App\Models\Minifig;
 use App\Models\Part;
 use App\Models\Product;
 use Inertia\Response;
@@ -13,28 +15,38 @@ class ProductController extends Controller
 {
     public function show(Product $product): Response
     {
-        $product->load('productable.partColors.media', 'color');
+        $product->load(ProductListingQuery::defaultWith());
 
         $suggestions = collect();
 
-        // If the product is a part, show suggestions
         if ($product->productable instanceof Part) {
             $bricklinkId = str($product->productable->bricklink_id)
-                // Strip everything after the first letter
                 ->replaceMatches('/[a-zA-Z].*/', '')
                 ->toString();
 
             $suggestions = Product::query()
                 ->whereMorphedTo('productable', Part::class)
-                ->whereHas('productable', function ($query) use ($bricklinkId) {
+                ->whereHas('productable', function ($query) use ($bricklinkId): void {
                     $query->where('bricklink_id', 'like', "{$bricklinkId}%");
                 })
                 ->where('id', '!=', $product->id)
                 ->where('productable_id', '!=', $product->productable_id)
-                ->with(['color', 'productable'])
+                ->where('stock', '>', 0)
+                ->with(ProductListingQuery::forType('part'))
                 ->limit(10)
                 ->get()
-                ->unique(fn (Product $product) => "{$product->productable_type}-{$product->productable_id}");
+                ->unique(fn (Product $product): string => "{$product->productable_type}-{$product->productable_id}");
+        }
+
+        if ($product->productable instanceof Minifig) {
+            $suggestions = Product::query()
+                ->whereMorphedTo('productable', Minifig::class)
+                ->where('id', '!=', $product->id)
+                ->where('stock', '>', 0)
+                ->with(ProductListingQuery::forType('minifig'))
+                ->orderByDesc('stock')
+                ->limit(10)
+                ->get();
         }
 
         return inertia('shop/product', [

--- a/app/Http/Controllers/SetController.php
+++ b/app/Http/Controllers/SetController.php
@@ -5,18 +5,25 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Http\Resources\Set\SetResource;
+use App\Models\Minifig;
 use App\Models\Part;
+use App\Models\PartCategory;
 use App\Models\Pivots\PartColor;
 use App\Models\Product;
 use App\Models\Set;
+use App\Support\BricqerImageUrl;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Inertia\Response;
 
 class SetController extends Controller
 {
-    public function show(Set $set): Response
+    public function show(Request $request, Set $set): Response
     {
         $set->load('media');
+
+        $categoryId = $request->integer('category_id') ?: null;
+        $colorId = $request->integer('color_id') ?: null;
 
         $partQuantities = DB::table('inventory_parts')
             ->join('inventories', 'inventories.id', '=', 'inventory_parts.inventory_id')
@@ -25,52 +32,85 @@ class SetController extends Controller
             ->select('inventory_parts.part_id', DB::raw('SUM(inventory_parts.quantity) as quantity'))
             ->pluck('quantity', 'part_id');
 
-        $allPartIds = $partQuantities->keys();
+        $minifigQuantities = DB::table('inventory_minifigs')
+            ->join('inventories', 'inventories.id', '=', 'inventory_minifigs.inventory_id')
+            ->where('inventories.set_id', $set->id)
+            ->groupBy('inventory_minifigs.minifig_id')
+            ->select('inventory_minifigs.minifig_id', DB::raw('SUM(inventory_minifigs.quantity) as quantity'))
+            ->pluck('quantity', 'minifig_id');
 
-        $products = Product::whereIn('productable_id', $allPartIds)
-            ->where('productable_type', Part::class)
-            ->with(['productable.partColors.media', 'color'])
-            ->get()
+        $partQuery = Product::query()
+            ->where('productable_type', (new Part)->getMorphClass())
+            ->whereIn('productable_id', $partQuantities->keys())
+            ->with(\App\Domain\Product\Queries\ProductListingQuery::forType('part'))
+            ->when($colorId, fn ($q) => $q->where('color_id', $colorId))
+            ->when($categoryId, function ($q) use ($categoryId): void {
+                $q->whereHasMorph('productable', [Part::class], fn ($p) => $p->where('part_category_id', $categoryId));
+            });
+
+        $partProducts = $partQuery->get()
             ->sortByDesc('stock')
             ->unique('productable_id')
             ->values();
 
-        $partIdsWithProducts = $products->pluck('productable_id')->unique();
+        $minifigProducts = Product::query()
+            ->where('productable_type', (new Minifig)->getMorphClass())
+            ->whereIn('productable_id', $minifigQuantities->keys())
+            ->with(['productable.media', 'color'])
+            ->get()
+            ->sortByDesc('stock')
+            ->values();
 
-        $partsWithoutProducts = Part::whereIn('id', $allPartIds->diff($partIdsWithProducts)->values())
-            ->get();
-
-        $productItems = $products->map(fn (Product $product): array => [
+        $mapPart = fn (Product $product): array => [
             'id' => $product->id,
             'title' => $product->productable->name,
             'lego_number' => $product->productable->bricklink_id,
-            'image' => $this->getPartImage($product->productable, $product->color_id),
+            'image' => $this->getPartImage($product->productable, (int) $product->color_id),
             'stock' => $product->stock > 100 ? 101 : $product->stock,
             'price' => $product->price,
             'url' => route('product.show', $product->id),
             'color' => $product->color ? ['name' => $product->color->name, 'hex' => $product->color->hex] : null,
             'quantity_in_set' => (int) ($partQuantities[$product->productable_id] ?? 1),
-        ]);
+            'type' => 'part',
+        ];
 
-        $unavailableItems = $partsWithoutProducts->map(fn (Part $part): array => [
-            'id' => null,
-            'title' => $part->name,
-            'lego_number' => $part->bricklink_id,
-            'image' => null,
-            'stock' => 0,
-            'price' => null,
-            'url' => null,
+        $mapMinifig = fn (Product $product): array => [
+            'id' => $product->id,
+            'title' => $product->productable->name,
+            'lego_number' => $product->productable->bricklink_id,
+            'image' => $this->getMinifigImage($product->productable),
+            'stock' => $product->stock > 100 ? 101 : $product->stock,
+            'price' => $product->price,
+            'url' => route('product.show', $product->id),
             'color' => null,
-            'quantity_in_set' => (int) ($partQuantities[$part->id] ?? 1),
-        ]);
+            'quantity_in_set' => (int) ($minifigQuantities[$product->productable_id] ?? 1),
+            'type' => 'minifig',
+        ];
+
+        $inStock = $partProducts->filter(fn (Product $p): bool => $p->stock > 0)->map($mapPart)
+            ->merge($minifigProducts->filter(fn (Product $p): bool => $p->stock > 0)->map($mapMinifig))
+            ->values();
+
+        $outOfStock = $partProducts->filter(fn (Product $p): bool => $p->stock === 0)->map($mapPart)
+            ->merge($minifigProducts->filter(fn (Product $p): bool => $p->stock === 0)->map($mapMinifig))
+            ->values();
+
+        $categories = PartCategory::query()
+            ->whereIn('id', Part::query()->whereIn('id', $partQuantities->keys())->pluck('part_category_id'))
+            ->orderBy('name')
+            ->get(['id', 'name']);
 
         return inertia('sets/show', [
             'set' => SetResource::make($set),
-            'in_stock_parts' => $productItems->filter(fn (array $p): bool => $p['stock'] > 0)->values(),
-            'out_of_stock_parts' => $productItems
-                ->filter(fn (array $p): bool => $p['stock'] === 0)
-                ->merge($unavailableItems)
-                ->values(),
+            'in_stock_parts' => $inStock,
+            'out_of_stock_parts' => $outOfStock,
+            'filters' => [
+                'categories' => $categories,
+            ],
+            'active' => [
+                'category_id' => $categoryId,
+                'color_id' => $colorId,
+            ],
         ]);
     }
 
@@ -78,8 +118,33 @@ class SetController extends Controller
     {
         $partColor = $part->partColors->firstWhere('color_id', $colorId);
 
-        return $partColor
+        $media = $partColor
             ?->getFirstMedia(PartColor::BRICQER_IMAGE_COLLECTION)
             ?->getAvailableUrl([PartColor::LARGE_CONVERSION]);
+
+        if ($media) {
+            return $media;
+        }
+
+        if ($part->bricklink_id && $partColor?->color?->bricklink_color_id) {
+            return BricqerImageUrl::part($part->bricklink_id, $partColor->color->bricklink_color_id);
+        }
+
+        return null;
+    }
+
+    private function getMinifigImage(Minifig $minifig): ?string
+    {
+        $media = $minifig
+            ->getFirstMedia(Minifig::BRICQER_IMAGE_COLLECTION)
+            ?->getAvailableUrl([Minifig::LARGE_CONVERSION]);
+
+        if ($media) {
+            return $media;
+        }
+
+        return $minifig->bricklink_id
+            ? BricqerImageUrl::minifig($minifig->bricklink_id)
+            : null;
     }
 }

--- a/app/Http/Controllers/SetIndexController.php
+++ b/app/Http/Controllers/SetIndexController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\Set\SetResource;
+use App\Models\Set;
+use Illuminate\Http\Request;
+use Inertia\Response;
+
+class SetIndexController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        $q = trim((string) $request->query('q', ''));
+
+        $sets = Set::query()
+            ->with('media')
+            ->when($q !== '', function ($query) use ($q): void {
+                $query->where(function ($inner) use ($q): void {
+                    $inner->where('name', 'like', "%{$q}%")
+                        ->orWhere('set_num', 'like', "%{$q}%");
+                });
+            })
+            ->orderByDesc('year')
+            ->paginate(36)
+            ->withQueryString();
+
+        return inertia('sets/index', [
+            'sets' => SetResource::collection($sets),
+            'query' => $q,
+        ]);
+    }
+}

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Article;
+use App\Models\Page;
+use App\Models\Product;
+use App\Models\Set;
+use Illuminate\Http\Response;
+
+class SitemapController extends Controller
+{
+    public function __invoke(): Response
+    {
+        $urls = collect([
+            ['loc' => url('/'), 'changefreq' => 'daily', 'priority' => '1.0'],
+            ['loc' => route('catalog.parts'), 'changefreq' => 'daily', 'priority' => '0.9'],
+            ['loc' => route('catalog.minifigs'), 'changefreq' => 'daily', 'priority' => '0.9'],
+            ['loc' => route('sets.index'), 'changefreq' => 'weekly', 'priority' => '0.8'],
+            ['loc' => url('/blog'), 'changefreq' => 'weekly', 'priority' => '0.6'],
+        ]);
+
+        Product::query()->select('id', 'updated_at')->orderBy('id')->chunk(500, function ($products) use (&$urls): void {
+            foreach ($products as $product) {
+                $urls->push([
+                    'loc' => route('product.show', $product),
+                    'lastmod' => optional($product->updated_at)->toAtomString(),
+                    'changefreq' => 'daily',
+                    'priority' => '0.7',
+                ]);
+            }
+        });
+
+        Set::query()->select('id', 'updated_at')->orderBy('id')->chunk(500, function ($sets) use (&$urls): void {
+            foreach ($sets as $set) {
+                $urls->push([
+                    'loc' => route('sets.show', $set),
+                    'lastmod' => optional($set->updated_at)->toAtomString(),
+                    'changefreq' => 'weekly',
+                    'priority' => '0.6',
+                ]);
+            }
+        });
+
+        Article::query()->where('is_published', true)->each(function (Article $article) use (&$urls): void {
+            $urls->push([
+                'loc' => url('/blog/'.$article->slug),
+                'lastmod' => optional($article->updated_at)->toAtomString(),
+                'changefreq' => 'monthly',
+                'priority' => '0.5',
+            ]);
+        });
+
+        Page::query()->where('is_published', true)->each(function (Page $page) use (&$urls): void {
+            $urls->push([
+                'loc' => route('pages.show', $page),
+                'lastmod' => optional($page->updated_at)->toAtomString(),
+                'changefreq' => 'monthly',
+                'priority' => '0.5',
+            ]);
+        });
+
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>'
+            .'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+
+        foreach ($urls as $url) {
+            $xml .= '<url>'
+                .'<loc>'.e($url['loc']).'</loc>'
+                .(isset($url['lastmod']) && $url['lastmod'] ? '<lastmod>'.e($url['lastmod']).'</lastmod>' : '')
+                .'<changefreq>'.e($url['changefreq']).'</changefreq>'
+                .'<priority>'.e($url['priority']).'</priority>'
+                .'</url>';
+        }
+
+        $xml .= '</urlset>';
+
+        return response($xml, 200, ['Content-Type' => 'application/xml']);
+    }
+}

--- a/app/Http/Resources/Minifig/MinifigSearchResource.php
+++ b/app/Http/Resources/Minifig/MinifigSearchResource.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Minifig;
+
+use App\Models\Minifig;
+use App\Models\Product;
+use App\Support\BricqerImageUrl;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Minifig
+ */
+class MinifigSearchResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        $this->loadMissing(['media', 'products']);
+
+        /** @var Product|null $product */
+        $product = $this->products
+            ->sortByDesc('stock')
+            ->first();
+
+        $price = $product?->price;
+
+        return [
+            'id' => $product?->id ?? $this->id,
+            'title' => $this->name,
+            'lego_number' => $this->bricklink_id,
+            'rebrickable_id' => $this->rebrickable_id,
+            'url' => $product !== null
+                ? route('product.show', $product->id)
+                : route('catalog.minifigs'),
+            'image' => $this->imageUrl(),
+            'priceMin' => $price,
+            'priceMax' => $price,
+            'sibling_colors' => [],
+            'type' => 'minifig',
+        ];
+    }
+
+    protected function imageUrl(): ?string
+    {
+        $mediaUrl = $this
+            ->getFirstMedia(Minifig::BRICQER_IMAGE_COLLECTION)
+            ?->getAvailableUrl([Minifig::THUMB_CONVERSION]);
+
+        if ($mediaUrl) {
+            return $mediaUrl;
+        }
+
+        return $this->bricklink_id
+            ? BricqerImageUrl::minifig((string) $this->bricklink_id)
+            : null;
+    }
+}

--- a/app/Http/Resources/Product/ProductResource.php
+++ b/app/Http/Resources/Product/ProductResource.php
@@ -9,6 +9,7 @@ use App\Models\Minifig;
 use App\Models\Part;
 use App\Models\Pivots\PartColor;
 use App\Models\Product;
+use App\Support\BricqerImageUrl;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -20,43 +21,52 @@ class ProductResource extends JsonResource
 {
     public function toArray(Request $request): array
     {
-        $this->loadMissing('productable.partColors', 'color');
+        $this->loadMissing(['color', 'productable']);
+
+        if ($this->productable instanceof Part) {
+            $this->productable->loadMissing(['partColors.media', 'partCategory', 'products.color']);
+        }
+
+        if ($this->productable instanceof Minifig) {
+            $this->productable->loadMissing('media');
+        }
+
+        $productable = $this->productable;
 
         return [
             'id' => $this->id,
             'stock' => $this->getSafeStock($this->stock),
             'price' => $this->price,
-
             'title' => $this->getTitle(),
             'image' => $this->getImage(),
-            'lego_number' => $this->productable->bricklink_id,
-
-            'color' => ColorResource::make($this->color),
-
+            'lego_number' => $productable->bricklink_id,
+            'rebrickable_id' => $productable->rebrickable_id ?? null,
+            'type' => $productable instanceof Minifig ? 'minifig' : 'part',
+            'category' => $productable instanceof Part
+                ? $productable->partCategory?->name
+                : null,
+            'color' => $this->shouldShowColor()
+                ? ColorResource::make($this->color)
+                : null,
             'url' => route('product.show', $this->id),
-
-            ...$this->productable instanceof Part
-                ? ['sibling_colors' => $this->productable->products->map(fn (Product $product): array => [
+            'attributes' => $this->attributesList(),
+            ...$productable instanceof Part
+                ? ['sibling_colors' => $productable->products->map(fn (Product $product): array => [
                     'id' => $product->id,
                     'stock' => $this->getSafeStock($product->stock),
                     'price' => $product->price,
-
                     'image' => $this->getPartImage($product->productable, $product->color_id),
-
                     'color' => ColorResource::make($product->color),
+                    'url' => route('product.show', $product->id),
                 ])]
-                : [],
+                : ['sibling_colors' => []],
         ];
     }
 
     protected function getTitle(): string
     {
-        if ($this->productable instanceof Part) {
-            return $this->productable->name;
-        }
-
-        if ($this->productable instanceof Minifig) {
-            return $this->productable->name;
+        if ($this->productable instanceof Part || $this->productable instanceof Minifig) {
+            return (string) $this->productable->name;
         }
 
         throw new Exception('Productable type not found');
@@ -66,18 +76,94 @@ class ProductResource extends JsonResource
     {
         $partColor = $part->partColors->firstWhere('color_id', $colorId);
 
-        return $partColor
+        $mediaUrl = $partColor
             ?->getFirstMedia(PartColor::BRICQER_IMAGE_COLLECTION)
             ?->getAvailableUrl([PartColor::LARGE_CONVERSION]);
+
+        if ($mediaUrl) {
+            return $mediaUrl;
+        }
+
+        $bricklinkId = $part->bricklink_id;
+        $blColor = $partColor?->color?->bricklink_color_id
+            ?? $this->color?->bricklink_color_id;
+
+        if ($bricklinkId && $blColor !== null) {
+            return BricqerImageUrl::part($bricklinkId, $blColor);
+        }
+
+        return null;
     }
 
     protected function getImage(): ?string
     {
         if ($this->productable instanceof Part) {
-            return $this->getPartImage($this->productable, $this->color_id);
+            return $this->getPartImage($this->productable, (int) $this->color_id);
         }
 
-        throw new Exception('Not implemented');
+        if ($this->productable instanceof Minifig) {
+            return $this->getMinifigImage($this->productable);
+        }
+
+        return null;
+    }
+
+    protected function getMinifigImage(Minifig $minifig): ?string
+    {
+        $mediaUrl = $minifig
+            ->getFirstMedia(Minifig::BRICQER_IMAGE_COLLECTION)
+            ?->getAvailableUrl([Minifig::LARGE_CONVERSION]);
+
+        if ($mediaUrl) {
+            return $mediaUrl;
+        }
+
+        return $minifig->bricklink_id
+            ? BricqerImageUrl::minifig($minifig->bricklink_id)
+            : null;
+    }
+
+    protected function shouldShowColor(): bool
+    {
+        if ($this->productable instanceof Minifig) {
+            return false;
+        }
+
+        return $this->color !== null
+            && $this->color->bricklink_color_id !== '0'
+            && $this->color->name !== '(Not Applicable)';
+    }
+
+    /**
+     * @return list<array{label: string, value: string}>
+     */
+    protected function attributesList(): array
+    {
+        $attrs = [
+            ['label' => 'Type', 'value' => $this->productable instanceof Minifig ? 'Minifiguur' : 'Onderdeel'],
+            ['label' => 'LEGO-nummer', 'value' => (string) ($this->productable->bricklink_id ?? '—')],
+        ];
+
+        if ($this->productable instanceof Part && $this->productable->rebrickable_id) {
+            $attrs[] = ['label' => 'Rebrickable', 'value' => (string) $this->productable->rebrickable_id];
+        }
+
+        if ($this->productable instanceof Part && $this->productable->partCategory) {
+            $attrs[] = ['label' => 'Categorie', 'value' => (string) $this->productable->partCategory->name];
+        }
+
+        if ($this->shouldShowColor() && $this->color) {
+            $attrs[] = ['label' => 'Kleur', 'value' => (string) $this->color->name];
+        }
+
+        $weight = data_get($this->productable, 'weight_grams');
+        if ($weight !== null) {
+            $attrs[] = ['label' => 'Gewicht', 'value' => rtrim(rtrim(number_format((float) $weight, 4, '.', ''), '0'), '.').' g'];
+        }
+
+        $attrs[] = ['label' => 'Voorraad', 'value' => (string) $this->getSafeStock($this->stock)];
+
+        return $attrs;
     }
 
     protected function getSafeStock(int $stock): int

--- a/app/Http/Resources/Product/ProductSearchResource.php
+++ b/app/Http/Resources/Product/ProductSearchResource.php
@@ -5,38 +5,51 @@ declare(strict_types=1);
 namespace App\Http\Resources\Product;
 
 use App\Http\Resources\Color\ColorResource;
+use App\Models\Minifig;
 use App\Models\Part;
 use App\Models\Product;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Http\Request;
 
 class ProductSearchResource extends ProductResource
 {
     public function toArray(Request $request): array
     {
-        $siblings = $this->productable->products;
-        $priceMin = $siblings->min('price');
-        $priceMax = $siblings->max('price');
+        $this->loadMissing([
+            'color',
+            'productable' => fn (MorphTo $morphTo) => $morphTo->morphWith([
+                Part::class => ['products.color', 'partColors.media'],
+                Minifig::class => ['media'],
+            ]),
+        ]);
+
+        $siblings = $this->productable instanceof Part
+            ? ($this->productable->products ?? collect())
+            : collect();
+        $priceMin = (int) ($siblings->min('price') ?? $this->price);
+        $priceMax = (int) ($siblings->max('price') ?? $this->price);
 
         return [
             'id' => $this->id,
             'title' => $this->productable->name,
-            'legoNumber' => $this->productable->bricklink_id,
-            'url' => "/products/{$this->id}",
+            'lego_number' => $this->productable->bricklink_id,
+            'url' => route('product.show', $this->id),
             'image' => $this->getImage(),
             'priceMin' => $priceMin,
             'priceMax' => $priceMax,
-            'lego_number' => $this->productable->bricklink_id,
-
-            ...$this->productable instanceof Part
-                ? ['sibling_colors' => $this->productable->products->map(fn (Product $product): array => [
-                    'id' => $product->id,
-                    'stock' => $this->getSafeStock($product->stock),
-                    'price' => $product->price,
-
-                    'image' => $this->getPartImage($product->productable, $product->color_id),
-
-                    'color' => ColorResource::make($product->color),
-                ])] : [],
+            'sibling_colors' => $this->productable instanceof Part
+                ? $siblings
+                    ->sortBy(fn (Product $product): string => $product->color?->name ?? '')
+                    ->values()
+                    ->map(fn (Product $product): array => [
+                        'id' => $product->id,
+                        'stock' => $this->getSafeStock($product->stock),
+                        'price' => $product->price,
+                        'image' => $this->getPartImage($product->productable, $product->color_id),
+                        'color' => ColorResource::make($product->color)->resolve(),
+                    ])
+                    ->all()
+                : [],
         ];
     }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -55,26 +55,45 @@ class Product extends Model implements Cartable
      */
     public function toSearchableArray(): array
     {
-        $this->loadMissing('productable');
+        $this->loadMissing([
+            'color',
+            'productable' => fn (MorphTo $morphTo) => $morphTo->morphWith([
+                Part::class => ['partCategory'],
+            ]),
+        ]);
+
+        $productable = $this->productable;
+        $type = $productable instanceof Minifig ? 'minifig' : 'part';
+        $categoryId = $productable instanceof Part ? $productable->part_category_id : null;
+        $categoryName = $productable instanceof Part
+            ? ($productable->partCategory?->name ?? '')
+            : '';
 
         return [
             'id' => (string) $this->id,
-            'name' => (string) ($this->productable->name ?? ''),
-            'bricklink_id' => (string) data_get($this->productable, 'bricklink_id', ''),
+            'name' => (string) ($productable->name ?? ''),
+            'bricklink_id' => (string) data_get($productable, 'bricklink_id', ''),
             'price' => (int) $this->price,
             'stock' => (int) $this->stock,
+            'type' => $type,
+            'color_id' => (int) ($this->color_id ?? 0),
+            'color_name' => (string) ($this->color?->name ?? ''),
+            'category_id' => (int) ($categoryId ?? 0),
+            'category_name' => (string) $categoryName,
         ];
     }
 
     /**
-     * Eager load the productable when (re)building the whole search index to
-     * avoid an N+1 query per product.
-     *
      * @param  Builder<Product>  $query
      * @return Builder<Product>
      */
     public function makeAllSearchableUsing(Builder $query): Builder
     {
-        return $query->with('productable');
+        return $query->with([
+            'color',
+            'productable' => fn (MorphTo $morphTo) => $morphTo->morphWith([
+                Part::class => ['partCategory'],
+            ]),
+        ]);
     }
 }

--- a/config/scout.php
+++ b/config/scout.php
@@ -57,7 +57,7 @@ return [
     |
     */
 
-    'after_commit' => false,
+    'after_commit' => env('SCOUT_AFTER_COMMIT', true),
 
     /*
     |--------------------------------------------------------------------------
@@ -153,11 +153,40 @@ return [
                             'name' => 'bricklink_id',
                             'type' => 'string',
                         ],
+                        [
+                            'name' => 'name',
+                            'type' => 'string',
+                        ],
                     ],
                     // 'default_sorting_field' => 'rebrickable_id',
                 ],
                 'search-parameters' => [
-                    'query_by' => 'name',
+                    'query_by' => 'name,bricklink_id,rebrickable_id',
+                ],
+            ],
+            App\Models\Minifig::class => [
+                'collection-schema' => [
+                    'fields' => [
+                        [
+                            'name' => 'id',
+                            'type' => 'string',
+                        ],
+                        [
+                            'name' => 'rebrickable_id',
+                            'type' => 'string',
+                        ],
+                        [
+                            'name' => 'bricklink_id',
+                            'type' => 'string',
+                        ],
+                        [
+                            'name' => 'name',
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+                'search-parameters' => [
+                    'query_by' => 'name,bricklink_id,rebrickable_id',
                 ],
             ],
             App\Models\Product::class => [
@@ -183,10 +212,40 @@ return [
                             'name' => 'stock',
                             'type' => 'int32',
                         ],
+                        [
+                            'name' => 'type',
+                            'type' => 'string',
+                            'facet' => true,
+                        ],
+                        [
+                            'name' => 'color_id',
+                            'type' => 'int32',
+                            'facet' => true,
+                            'optional' => true,
+                        ],
+                        [
+                            'name' => 'color_name',
+                            'type' => 'string',
+                            'facet' => true,
+                            'optional' => true,
+                        ],
+                        [
+                            'name' => 'category_id',
+                            'type' => 'int32',
+                            'facet' => true,
+                            'optional' => true,
+                        ],
+                        [
+                            'name' => 'category_name',
+                            'type' => 'string',
+                            'facet' => true,
+                            'optional' => true,
+                        ],
                     ],
                 ],
                 'search-parameters' => [
-                    'query_by' => 'name,bricklink_id',
+                    'query_by' => 'name,bricklink_id,color_name,category_name',
+                    'num_typos' => 2,
                 ],
             ],
             App\Models\Set::class => [

--- a/resources/js/components/Navigation/SearchResults.jsx
+++ b/resources/js/components/Navigation/SearchResults.jsx
@@ -10,7 +10,7 @@ import InlineSet from "../Shop/Sets/InlineSet.jsx";
  * @param {string} props.query
  */
 export default function SearchResults({ query }) {
-    const [results, setResults] = useState({ products: [], sets: [] });
+    const [results, setResults] = useState({ products: [], minifigs: [], sets: [] });
     const [isLoading, setIsLoading] = useState(false);
     const [activeTab, setActiveTab] = useState('products');
 
@@ -18,7 +18,7 @@ export default function SearchResults({ query }) {
 
     useEffect(() => {
         if (trimmedQuery === "") {
-            setResults({ products: [], sets: [] });
+            setResults({ products: [], minifigs: [], sets: [] });
             setIsLoading(false);
             return;
         }
@@ -31,15 +31,19 @@ export default function SearchResults({ query }) {
                 const data = await searchAll(trimmedQuery, { signal: controller.signal });
                 setResults(data);
                 setIsLoading(false);
-                // Auto-select the tab that has results
-                if (data.products.length === 0 && data.sets.length > 0) {
+                // Prefer the first tab that has results.
+                if (data.products.length > 0) {
+                    setActiveTab('products');
+                } else if (data.minifigs.length > 0) {
+                    setActiveTab('minifigs');
+                } else if (data.sets.length > 0) {
                     setActiveTab('sets');
                 } else {
                     setActiveTab('products');
                 }
             } catch (error) {
                 if (error.name !== "AbortError") {
-                    setResults({ products: [], sets: [] });
+                    setResults({ products: [], minifigs: [], sets: [] });
                     setIsLoading(false);
                 }
             }
@@ -67,9 +71,20 @@ export default function SearchResults({ query }) {
     }
 
     const hasProducts = results.products.length > 0;
+    const hasMinifigs = results.minifigs.length > 0;
     const hasSets = results.sets.length > 0;
-    const hasAny = hasProducts || hasSets;
-    const hasBoth = hasProducts && hasSets;
+    const hasAny = hasProducts || hasMinifigs || hasSets;
+    const tabCount = [hasProducts, hasMinifigs, hasSets].filter(Boolean).length;
+    const hasMultipleTabs = tabCount > 1;
+
+    const tabs = [
+        hasProducts && { key: 'products', label: `Onderdelen (${results.products.length})` },
+        hasMinifigs && { key: 'minifigs', label: `Minifiguren (${results.minifigs.length})` },
+        hasSets && { key: 'sets', label: `Sets (${results.sets.length})` },
+    ].filter(Boolean);
+
+    const activeTabIndex = Math.max(0, tabs.findIndex((tab) => tab.key === activeTab));
+    const panelWidthPct = tabs.length > 0 ? 100 / tabs.length : 100;
 
     const loadingOrEmpty = isLoading ? (
         <div className="flex items-center justify-center py-12 text-gray-400">
@@ -95,55 +110,59 @@ export default function SearchResults({ query }) {
                     <div className="flex-1">{loadingOrEmpty}</div>
                 ) : (
                     <>
-                        {/* Floating tab switcher — sits above the scroll area */}
-                        {hasBoth && (
-                            <div className="shrink-0 flex gap-2 px-4 py-3 bg-white shadow-md z-10">
-                                <button
-                                    onClick={() => setActiveTab('products')}
-                                    className={`flex-1 rounded-md px-4 py-2 text-sm font-medium transition border ${
-                                        activeTab === 'products'
-                                            ? 'bg-primary text-white border-primary'
-                                            : 'bg-white text-gray-600 border-gray-200 hover:bg-accent'
-                                    }`}
-                                >
-                                    Onderdelen ({results.products.length})
-                                </button>
-                                <button
-                                    onClick={() => setActiveTab('sets')}
-                                    className={`flex-1 rounded-md px-4 py-2 text-sm font-medium transition border ${
-                                        activeTab === 'sets'
-                                            ? 'bg-primary text-white border-primary'
-                                            : 'bg-white text-gray-600 border-gray-200 hover:bg-accent'
-                                    }`}
-                                >
-                                    Sets ({results.sets.length})
-                                </button>
+                        {hasMultipleTabs && (
+                            <div className="shrink-0 flex gap-2 px-4 py-3 bg-white shadow-md z-10 overflow-x-auto">
+                                {tabs.map((tab) => (
+                                    <button
+                                        key={tab.key}
+                                        onClick={() => setActiveTab(tab.key)}
+                                        className={`shrink-0 rounded-md px-4 py-2 text-sm font-medium transition border ${
+                                            activeTab === tab.key
+                                                ? 'bg-primary text-white border-primary'
+                                                : 'bg-white text-gray-600 border-gray-200 hover:bg-accent'
+                                        }`}
+                                    >
+                                        {tab.label}
+                                    </button>
+                                ))}
                             </div>
                         )}
 
-                        {/* Sliding track — each panel scrolls independently */}
                         <div className="flex-1 min-h-0 overflow-hidden">
                             <div
                                 className="flex h-full transition-transform duration-300 ease-in-out"
                                 style={{
-                                    width: '200%',
-                                    transform: `translateX(${activeTab === 'sets' ? '-50%' : '0%'})`,
+                                    width: `${tabs.length * 100}%`,
+                                    transform: `translateX(-${activeTabIndex * panelWidthPct}%)`,
                                 }}
                             >
-                                <div className="overflow-y-auto h-full px-4 py-4" style={{ width: '50%' }}>
-                                    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-                                        {results.products.map((product) => (
-                                            <InlineProduct key={product.id} product={product} />
-                                        ))}
+                                {hasProducts && (
+                                    <div className="overflow-y-auto h-full px-4 py-4" style={{ width: `${panelWidthPct}%` }}>
+                                        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+                                            {results.products.map((product) => (
+                                                <InlineProduct key={product.id} product={product} />
+                                            ))}
+                                        </div>
                                     </div>
-                                </div>
-                                <div className="overflow-y-auto h-full px-4 py-4" style={{ width: '50%' }}>
-                                    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-                                        {results.sets.map((set) => (
-                                            <InlineSet key={set.id} set={set} />
-                                        ))}
+                                )}
+                                {hasMinifigs && (
+                                    <div className="overflow-y-auto h-full px-4 py-4" style={{ width: `${panelWidthPct}%` }}>
+                                        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+                                            {results.minifigs.map((minifig) => (
+                                                <InlineProduct key={`minifig-${minifig.id}`} product={minifig} />
+                                            ))}
+                                        </div>
                                     </div>
-                                </div>
+                                )}
+                                {hasSets && (
+                                    <div className="overflow-y-auto h-full px-4 py-4" style={{ width: `${panelWidthPct}%` }}>
+                                        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+                                            {results.sets.map((set) => (
+                                                <InlineSet key={set.id} set={set} />
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
                             </div>
                         </div>
                     </>
@@ -162,6 +181,18 @@ export default function SearchResults({ query }) {
                                 <div className="grid grid-cols-4 gap-4 xl:grid-cols-5">
                                     {results.products.map((product) => (
                                         <InlineProduct key={product.id} product={product} />
+                                    ))}
+                                </div>
+                            </section>
+                        )}
+                        {hasMinifigs && (
+                            <section>
+                                <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-4">
+                                    Minifiguren
+                                </h4>
+                                <div className="grid grid-cols-4 gap-4 xl:grid-cols-5">
+                                    {results.minifigs.map((minifig) => (
+                                        <InlineProduct key={`minifig-${minifig.id}`} product={minifig} />
                                     ))}
                                 </div>
                             </section>

--- a/resources/js/components/Shop/Products/InlineProduct.jsx
+++ b/resources/js/components/Shop/Products/InlineProduct.jsx
@@ -12,9 +12,11 @@ import "react-tooltip/dist/react-tooltip.css";
  * @param {import("../../../services/search.js").ProductResult} props.product
  */
 export default function InlineProduct({ product }) {
-    let { priceMin, priceMax, colors = [] } = product;
+    const siblingColors = product.sibling_colors ?? [];
+    let priceMin = product.priceMin;
+    let priceMax = product.priceMax;
 
-    if(!priceMin || !priceMax) {
+    if (priceMin == null || priceMax == null) {
         priceMin = product.price;
         priceMax = product.price;
     }
@@ -49,32 +51,32 @@ export default function InlineProduct({ product }) {
                 <p className="text-sm font-semibold text-gray-900">{priceLabel}</p>
             </div>
 
-            {product.sibling_colors.length > 0 && (
+            {siblingColors.length > 0 && (
                 <>
                     <span data-tooltip-id={tooltipId} className="flex items-center gap-1">
-                        {product.sibling_colors.slice(0, 6).map(sibling => (
+                        {siblingColors.slice(0, 6).map((sibling) => (
                             <span
-                                key={sibling.color.name}
+                                key={sibling.id ?? sibling.color?.name}
                                 className="h-3 w-3 rounded-full border border-gray-200"
-                                style={{ backgroundColor: `#${sibling.color.hex}` }}
+                                style={{ backgroundColor: `#${sibling.color?.hex ?? 'ccc'}` }}
                             />
                         ))}
 
-                        {product.sibling_colors.length > 6 && (
-                            <span className="text-xs text-gray-400">+{product.sibling_colors.length - 6}</span>
+                        {siblingColors.length > 6 && (
+                            <span className="text-xs text-gray-400">+{siblingColors.length - 6}</span>
                         )}
                     </span>
 
                     <ReactTooltip id={tooltipId} place="top" className="z-50">
                         <span className="flex flex-col gap-1">
-                            {product.sibling_colors.map(sibling => (
-                                <span key={sibling.color.name} className="flex items-center gap-2 whitespace-nowrap">
+                            {siblingColors.map((sibling) => (
+                                <span key={sibling.id ?? sibling.color?.name} className="flex items-center gap-2 whitespace-nowrap">
                                     <span
                                         className="inline-block h-3 w-3 shrink-0 rounded-sm border border-white/30"
-                                        style={{ backgroundColor: `#${sibling.color.hex}` }}
+                                        style={{ backgroundColor: `#${sibling.color?.hex ?? 'ccc'}` }}
                                     />
-                                    <span className="flex-1">{sibling.color.name}</span>
-                                    <span className="text-gray-300">{sibling.color.stock}</span>
+                                    <span className="flex-1">{sibling.color?.name}</span>
+                                    <span className="text-gray-300">{sibling.stock}</span>
                                 </span>
                             ))}
                         </span>

--- a/resources/js/components/Shop/Products/ProductSiblingsOverview.jsx
+++ b/resources/js/components/Shop/Products/ProductSiblingsOverview.jsx
@@ -5,7 +5,7 @@ export default function ProductSiblingsOverview({ productSiblings }) {
         <div>
             <h3 className="text-lg font-semibold mb-2">Andere kleuren:</h3>
 
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap gap-2 max-w-md">
                 {productSiblings.map((sibling) => (
                     <ColorPreview key={sibling.id} product={sibling} />
                 ))}

--- a/resources/js/pages/sets/index.jsx
+++ b/resources/js/pages/sets/index.jsx
@@ -1,0 +1,38 @@
+import { Link, router } from '@inertiajs/react';
+import Container from '../../components/Container';
+import InlineSet from '../../components/Shop/Sets/InlineSet';
+
+export default function SetsIndex({ sets, query }) {
+    const items = sets?.data ?? [];
+
+    return (
+        <Container className="max-w-7xl my-8">
+            <div className="flex flex-col md:flex-row md:items-end justify-between gap-4 mb-8">
+                <h1 className="text-3xl font-bold">Sets</h1>
+                <form
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        router.get('/sets', { q: e.target.q.value }, { preserveState: true });
+                    }}
+                >
+                    <input
+                        name="q"
+                        defaultValue={query ?? ''}
+                        placeholder="Zoek setnummer of naam..."
+                        className="border border-gray-200 rounded-lg px-4 py-2 w-full md:w-80"
+                    />
+                </form>
+            </div>
+
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+                {items.map((set) => (
+                    <InlineSet key={(set.data ?? set).id} set={set.data ?? set} />
+                ))}
+            </div>
+
+            {items.length === 0 && (
+                <p className="text-gray-500">Geen sets gevonden.</p>
+            )}
+        </Container>
+    );
+}

--- a/resources/js/pages/shop/catalog.jsx
+++ b/resources/js/pages/shop/catalog.jsx
@@ -1,0 +1,112 @@
+import { Link, router } from '@inertiajs/react';
+import Container from '../../components/Container';
+import InlineProduct from '../../components/Shop/Products/InlineProduct';
+import AddToCartButton from '../../components/Shop/Products/AddToCartButton';
+
+export default function CatalogPage({ title, type, query, products, filters, active }) {
+    const items = products?.data ?? products ?? [];
+    const meta = products?.meta ?? products?.links ? products : null;
+
+    function updateFilter(key, value) {
+        const params = { ...active, [key]: value || undefined };
+        Object.keys(params).forEach((k) => {
+            if (params[k] == null || params[k] === '') delete params[k];
+        });
+        const path = type === 'minifig' ? '/minifiguren' : type === 'search' ? '/zoeken' : '/onderdelen';
+        router.get(path, params, { preserveState: true, preserveScroll: true });
+    }
+
+    return (
+        <Container className="max-w-7xl my-8">
+            <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-8">
+                <div>
+                    <h1 className="text-3xl font-bold text-gray-900">{title}</h1>
+                    {type === 'search' && (
+                        <form
+                            className="mt-4"
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                updateFilter('q', e.target.q.value);
+                            }}
+                        >
+                            <input
+                                name="q"
+                                defaultValue={query ?? ''}
+                                placeholder="Zoek op naam of LEGO-nummer..."
+                                className="w-full md:w-96 border border-gray-200 rounded-lg px-4 py-2"
+                            />
+                        </form>
+                    )}
+                </div>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
+                <aside className="space-y-6">
+                    {filters?.categories?.length > 0 && (
+                        <div>
+                            <h2 className="text-sm font-semibold text-gray-700 mb-2">Categorie</h2>
+                            <select
+                                className="w-full border border-gray-200 rounded-md px-3 py-2"
+                                value={active?.category_id ?? ''}
+                                onChange={(e) => updateFilter('category_id', e.target.value)}
+                            >
+                                <option value="">Alle categorieën</option>
+                                {filters.categories.map((c) => (
+                                    <option key={c.id} value={c.id}>{c.name}</option>
+                                ))}
+                            </select>
+                        </div>
+                    )}
+                    {filters?.colors?.length > 0 && (
+                        <div>
+                            <h2 className="text-sm font-semibold text-gray-700 mb-2">Kleur</h2>
+                            <select
+                                className="w-full border border-gray-200 rounded-md px-3 py-2"
+                                value={active?.color_id ?? ''}
+                                onChange={(e) => updateFilter('color_id', e.target.value)}
+                            >
+                                <option value="">Alle kleuren</option>
+                                {filters.colors.map((c) => (
+                                    <option key={c.id} value={c.id}>{c.name}</option>
+                                ))}
+                            </select>
+                        </div>
+                    )}
+                </aside>
+
+                <div className="lg:col-span-3">
+                    {items.length === 0 ? (
+                        <p className="text-gray-500">Geen producten gevonden.</p>
+                    ) : (
+                        <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 gap-4">
+                            {items.map((product) => {
+                                const p = product.data ?? product;
+                                return (
+                                    <div key={p.id} className="flex flex-col gap-2">
+                                        <InlineProduct product={p} />
+                                        <AddToCartButton product={p} />
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+
+                    {meta?.links && (
+                        <div className="mt-8 flex flex-wrap gap-2">
+                            {meta.links.map((link, i) => (
+                                link.url ? (
+                                    <Link
+                                        key={i}
+                                        href={link.url}
+                                        className={`px-3 py-1 rounded border text-sm ${link.active ? 'bg-primary text-white border-primary' : 'border-gray-200'}`}
+                                        dangerouslySetInnerHTML={{ __html: link.label }}
+                                    />
+                                ) : null
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </Container>
+    );
+}

--- a/resources/js/pages/shop/product.jsx
+++ b/resources/js/pages/shop/product.jsx
@@ -1,6 +1,7 @@
 import { MinusIcon } from '@phosphor-icons/react/dist/csr/Minus';
 import { PlusIcon } from '@phosphor-icons/react/dist/csr/Plus';
 import { ShoppingCartIcon } from '@phosphor-icons/react/dist/csr/ShoppingCart';
+import { router } from '@inertiajs/react';
 import { useState } from 'react';
 import Button from '../../components/UI/Button';
 import Container from '../../components/Container';
@@ -12,10 +13,8 @@ import InlineProduct from "../../components/Shop/Products/InlineProduct.jsx";
 
 /**
  * @param {Object} props
- * @param {{ id: number, name: string, image: string|null, price: number, stock: number, color: { name: string|null, hex: string|null } }} props.product
  */
-export default function ProductPage({ product: { data: product }, suggestions: { data: suggestions } }) {
-    console.log(product, suggestions)
+export default function ProductPage({ product: { data: product }, suggestions: { data: suggestions }, status }) {
     const { items, addItem, open, processing } = useCart();
 
     const currentCartQty = items.find((i) => i.id === product.id)?.quantity ?? 0;
@@ -24,6 +23,8 @@ export default function ProductPage({ product: { data: product }, suggestions: {
     const isProcessing = processing === product.id;
 
     const [quantity, setQuantity] = useState(1);
+    const [notifyEmail, setNotifyEmail] = useState('');
+    const [notifySent, setNotifySent] = useState(false);
 
     function decrement() {
         setQuantity((q) => Math.max(1, q - 1));
@@ -45,7 +46,7 @@ export default function ProductPage({ product: { data: product }, suggestions: {
     return (
         <Container className="max-w-250 my-8">
             <div className="py-10 grid grid-cols-1 md:grid-cols-5 gap-10 md:shadow-[0_0px_10px_rgba(0,0,0,0.1)] md:px-6 rounded-xl">
-                <div className="rounded-xl overflow-hidden flex items-center justify-center aspect-square md:col-span-2 max-h-60 md:max-h-none mx-auto">
+                <div className="rounded-xl overflow-hidden flex items-center justify-center md:col-span-2 max-h-60 md:max-h-none mx-auto">
                     {product.image ? (
                         <img
                             src={product.image}
@@ -95,9 +96,14 @@ export default function ProductPage({ product: { data: product }, suggestions: {
                                     <MinusIcon size={16} />
                                 </button>
 
-                                <span className="px-4 py-2 min-w-12 text-center font-medium tabular-nums w-full">
-                                    {quantity}
-                                </span>
+                                <input
+                                    type="number"
+                                    className="h-full py-2 px-2 w-[4ch] text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                                    min={1} value={quantity} // max={available}
+                                    onChange={e => setQuantity(
+                                        Math.max(1, Math.min(available, parseInt(e.target.value) || 1))
+                                    )}
+                                />
 
                                 <button
                                     className="px-3 py-2 hover:bg-gray-100 transition disabled:opacity-40 cursor-pointer"
@@ -119,11 +125,51 @@ export default function ProductPage({ product: { data: product }, suggestions: {
                             </Button>
                         </div>
                     ) : (
-                        <p className="text-sm text-gray-500">
-                            {product.stock === 0
-                                ? 'Dit product is momenteel uitverkocht'
-                                : 'Je hebt al de maximale hoeveelheid in je winkelmandje'}
-                        </p>
+                        <div className="space-y-3">
+                            <p className="text-sm text-gray-500">
+                                {product.stock === 0
+                                    ? 'Dit product is momenteel uitverkocht'
+                                    : 'Je hebt al de maximale hoeveelheid in je winkelmandje'}
+                            </p>
+                            {product.stock === 0 && (
+                                <form
+                                    className="flex flex-col sm:flex-row gap-2"
+                                    onSubmit={(e) => {
+                                        e.preventDefault();
+                                        router.post(`/products/${product.id}/stock-notifications`, {
+                                            email: notifyEmail,
+                                        }, {
+                                            preserveScroll: true,
+                                            onSuccess: () => setNotifySent(true),
+                                        });
+                                    }}
+                                >
+                                    <input
+                                        type="email"
+                                        required
+                                        value={notifyEmail}
+                                        onChange={(e) => setNotifyEmail(e.target.value)}
+                                        placeholder="jouw@email.nl"
+                                        className="flex-1 border border-gray-200 rounded-md px-3 py-2"
+                                    />
+                                    <Button type="submit" variant="primary">Houd me op de hoogte</Button>
+                                </form>
+                            )}
+                            {(notifySent || status) && (
+                                <p className="text-sm text-green-700">{status || 'Bedankt! We mailen je bij voorraad.'}</p>
+                            )}
+                        </div>
+                    )}
+
+                    {product.attributes?.length > 0 && (
+                        <dl className="mt-2 space-y-2 border-t border-gray-100 pt-4">
+                            {product.attributes.map((attr) => (
+                                <div key={attr.label} className="flex gap-4 text-sm">
+                                    <dt className="w-32 text-gray-500">{attr.label}</dt>
+                                    <dd className="font-medium text-gray-900">{attr.value}</dd>
+                                </div>
+                            ))}
+                        </dl>
                     )}
 
                     {product.sibling_colors?.length > 0 && (

--- a/resources/js/services/search.js
+++ b/resources/js/services/search.js
@@ -1,21 +1,36 @@
 /**
- * @typedef {Object} ProductColor
- * @property {string} name
- * @property {string} hex
+ * @typedef {Object} SiblingColor
+ * @property {number|string} id
  * @property {number} stock
+ * @property {number} price
+ * @property {?string} image
+ * @property {{ name: string, hex: string|null }} color
  */
 
 /**
  * @typedef {Object} ProductResult
  * @property {number|string} id
- * @property {string} name
+ * @property {string} title
  * @property {?string} image
  * @property {string} lego_number
  * @property {string} url
  * @property {?number} priceMin
  * @property {?number} priceMax
- * @property {?ProductColor} primaryColor
- * @property {ProductColor[]} colors
+ * @property {SiblingColor[]} sibling_colors
+ */
+
+/**
+ * @typedef {Object} MinifigResult
+ * @property {number|string} id
+ * @property {string} title
+ * @property {?string} image
+ * @property {?string} lego_number
+ * @property {?string} rebrickable_id
+ * @property {string} url
+ * @property {?number} priceMin
+ * @property {?number} priceMax
+ * @property {SiblingColor[]} sibling_colors
+ * @property {'minifig'} type
  */
 
 /**
@@ -32,11 +47,12 @@
 /**
  * @typedef {Object} SearchResults
  * @property {ProductResult[]} products
+ * @property {MinifigResult[]} minifigs
  * @property {SetResult[]} sets
  */
 
 /**
- * Searches for products and sets matching the given query.
+ * Searches for products, minifigs, and sets matching the given query.
  *
  * @param {string} query
  * @param {Object} [options]
@@ -47,7 +63,7 @@ export async function searchAll(query, { signal } = {}) {
     const term = query.trim();
 
     if (term === '') {
-        return { products: [], sets: [] };
+        return { products: [], minifigs: [], sets: [] };
     }
 
     const response = await fetch(`/api/search?q=${encodeURIComponent(term)}`, {
@@ -61,5 +77,9 @@ export async function searchAll(query, { signal } = {}) {
 
     const { data } = await response.json();
 
-    return data;
+    return {
+        products: data?.products ?? [],
+        minifigs: data?.minifigs ?? [],
+        sets: data?.sets ?? [],
+    };
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,4 +5,6 @@ declare(strict_types=1);
 use App\Http\Controllers\Api\SearchController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/search', SearchController::class)->name('api.search');
+Route::get('/search', SearchController::class)
+    ->middleware('throttle:api-search')
+    ->name('api.search');

--- a/tests/Feature/Api/SearchControllerTest.php
+++ b/tests/Feature/Api/SearchControllerTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests\Feature\Api;
 
 use App\Models\Color;
+use App\Models\Minifig;
 use App\Models\Part;
 use App\Models\Product;
+use App\Models\Set;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -21,11 +23,11 @@ class SearchControllerTest extends TestCase
 
         $this->getJson('/api/search?q=red')
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonPath('data.0.name', 'Red Brick 2x4')
-            ->assertJsonPath('data.0.legoNumber', '3001')
-            ->assertJsonPath('data.0.priceMin', 1.5)
-            ->assertJsonPath('data.0.colors.0.stock', 10);
+            ->assertJsonCount(1, 'data.products')
+            ->assertJsonPath('data.products.0.title', 'Red Brick 2x4')
+            ->assertJsonPath('data.products.0.lego_number', '3001')
+            ->assertJsonPath('data.products.0.priceMin', 150)
+            ->assertJsonPath('data.products.0.sibling_colors.0.stock', 10);
     }
 
     public function test_it_searches_products_by_bricklink_number(): void
@@ -35,8 +37,8 @@ class SearchControllerTest extends TestCase
 
         $this->getJson('/api/search?q=3023')
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonPath('data.0.name', 'Blue Plate 1x2');
+            ->assertJsonCount(1, 'data.products')
+            ->assertJsonPath('data.products.0.title', 'Blue Plate 1x2');
     }
 
     public function test_it_groups_color_variants_of_a_part_into_one_result(): void
@@ -48,34 +50,136 @@ class SearchControllerTest extends TestCase
 
         $this->getJson('/api/search?q=brick')
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonCount(2, 'data.0.colors')
-            // colors sorted by name asc -> "Azure" is primary.
-            ->assertJsonPath('data.0.primaryColor.name', 'Azure')
-            ->assertJsonPath('data.0.colors.0.name', 'Azure')
-            ->assertJsonPath('data.0.colors.0.stock', 3)
-            ->assertJsonPath('data.0.colors.1.name', 'Blue')
-            // min/max across variants, cents -> euros.
-            ->assertJsonPath('data.0.priceMin', 1.5)
-            ->assertJsonPath('data.0.priceMax', 2);
+            ->assertJsonCount(1, 'data.products')
+            ->assertJsonCount(2, 'data.products.0.sibling_colors')
+            ->assertJsonPath('data.products.0.sibling_colors.0.color.name', 'Azure')
+            ->assertJsonPath('data.products.0.sibling_colors.0.stock', 3)
+            ->assertJsonPath('data.products.0.sibling_colors.1.color.name', 'Blue')
+            ->assertJsonPath('data.products.0.priceMin', 150)
+            ->assertJsonPath('data.products.0.priceMax', 200);
+    }
+
+    public function test_it_searches_minifigs_by_name_and_bricklink_id(): void
+    {
+        Minifig::factory()->create([
+            'name' => 'Luke Skywalker',
+            'bricklink_id' => 'sw0001',
+            'rebrickable_id' => 'fig-000100',
+        ]);
+        Minifig::factory()->create([
+            'name' => 'Han Solo',
+            'bricklink_id' => 'sw0002',
+        ]);
+
+        $this->getJson('/api/search?q=luke')
+            ->assertOk()
+            ->assertJsonCount(1, 'data.minifigs')
+            ->assertJsonPath('data.minifigs.0.title', 'Luke Skywalker')
+            ->assertJsonPath('data.minifigs.0.lego_number', 'sw0001')
+            ->assertJsonPath('data.minifigs.0.type', 'minifig');
+
+        $this->getJson('/api/search?q=sw0002')
+            ->assertOk()
+            ->assertJsonCount(1, 'data.minifigs')
+            ->assertJsonPath('data.minifigs.0.title', 'Han Solo');
+    }
+
+    public function test_it_links_minifig_results_to_their_product_when_available(): void
+    {
+        $minifig = Minifig::factory()->create([
+            'name' => 'Darth Vader',
+            'bricklink_id' => 'sw0003',
+        ]);
+        $product = Product::factory()->create([
+            'productable_type' => $minifig->getMorphClass(),
+            'productable_id' => $minifig->id,
+            'color_id' => Color::factory(),
+            'price' => 1250,
+            'stock' => 4,
+        ]);
+
+        $this->getJson('/api/search?q=vader')
+            ->assertOk()
+            ->assertJsonCount(1, 'data.minifigs')
+            ->assertJsonPath('data.minifigs.0.priceMin', 1250)
+            ->assertJsonPath('data.minifigs.0.url', route('product.show', $product->id));
+    }
+
+    public function test_it_keeps_part_products_and_minifigs_in_separate_buckets(): void
+    {
+        $this->partWithColors('Red Brick 2x4', '3001', [['color' => 'Red', 'price' => 150, 'stock' => 10]]);
+
+        $minifig = Minifig::factory()->create([
+            'name' => 'Red Soldier',
+            'bricklink_id' => 'cas001',
+        ]);
+        Product::factory()->create([
+            'productable_type' => $minifig->getMorphClass(),
+            'productable_id' => $minifig->id,
+            'color_id' => Color::factory(),
+            'price' => 500,
+            'stock' => 2,
+        ]);
+
+        $this->getJson('/api/search?q=red')
+            ->assertOk()
+            ->assertJsonCount(1, 'data.products')
+            ->assertJsonCount(1, 'data.minifigs')
+            ->assertJsonPath('data.products.0.title', 'Red Brick 2x4')
+            ->assertJsonPath('data.minifigs.0.title', 'Red Soldier');
+    }
+
+    public function test_it_returns_sets_alongside_products_and_minifigs(): void
+    {
+        $this->partWithColors('Red Brick 2x4', '3001', [['color' => 'Red', 'price' => 150, 'stock' => 10]]);
+        Minifig::factory()->create(['name' => 'Red Guard', 'bricklink_id' => 'cas002']);
+        Set::factory()->create(['name' => 'Red Castle', 'set_num' => '375-1']);
+
+        $this->getJson('/api/search?q=red')
+            ->assertOk()
+            ->assertJsonCount(1, 'data.products')
+            ->assertJsonCount(1, 'data.minifigs')
+            ->assertJsonCount(1, 'data.sets')
+            ->assertJsonPath('data.sets.0.name', 'Red Castle');
     }
 
     public function test_it_returns_empty_for_a_blank_query(): void
     {
         $this->partWithColors('Red Brick 2x4', '3001', [['color' => 'Red', 'price' => 150, 'stock' => 10]]);
+        Minifig::factory()->create(['name' => 'Luke', 'bricklink_id' => 'sw0001']);
 
         $this->getJson('/api/search?q=')
             ->assertOk()
-            ->assertJsonCount(0, 'data');
+            ->assertJsonPath('data.products', [])
+            ->assertJsonPath('data.minifigs', [])
+            ->assertJsonPath('data.sets', []);
     }
 
     public function test_it_returns_empty_when_nothing_matches(): void
     {
         $this->partWithColors('Red Brick 2x4', '3001', [['color' => 'Red', 'price' => 150, 'stock' => 10]]);
+        Minifig::factory()->create(['name' => 'Luke', 'bricklink_id' => 'sw0001']);
 
         $this->getJson('/api/search?q=nonexistent')
             ->assertOk()
-            ->assertJsonCount(0, 'data');
+            ->assertJsonPath('data.products', [])
+            ->assertJsonPath('data.minifigs', [])
+            ->assertJsonPath('data.sets', []);
+    }
+
+    public function test_it_excludes_out_of_stock_products_from_search(): void
+    {
+        $this->partWithColors('Red Brick 2x4', '3001', [['color' => 'Red', 'price' => 150, 'stock' => 0]]);
+        $this->partWithColors('Blue Plate 1x2', '3023', [['color' => 'Blue', 'price' => 99, 'stock' => 4]]);
+
+        $this->getJson('/api/search?q=red')
+            ->assertOk()
+            ->assertJsonCount(0, 'data.products');
+
+        $this->getJson('/api/search?q=blue')
+            ->assertOk()
+            ->assertJsonCount(1, 'data.products')
+            ->assertJsonPath('data.products.0.title', 'Blue Plate 1x2');
     }
 
     /**

--- a/tests/Feature/Catalog/CatalogPagesTest.php
+++ b/tests/Feature/Catalog/CatalogPagesTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Catalog;
+
+use App\Models\Color;
+use App\Models\Minifig;
+use App\Models\Part;
+use App\Models\Product;
+use App\Models\Set;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CatalogPagesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_parts_catalog_page_renders(): void
+    {
+        $part = Part::factory()->create();
+        $color = Color::factory()->create();
+        Product::factory()->create([
+            'productable_type' => $part->getMorphClass(),
+            'productable_id' => $part->id,
+            'color_id' => $color->id,
+            'stock' => 5,
+        ]);
+
+        $this->get(route('catalog.parts'))->assertOk();
+    }
+
+    public function test_minifigs_catalog_page_renders(): void
+    {
+        $minifig = Minifig::factory()->create();
+        $color = Color::factory()->create(['bricklink_color_id' => '0']);
+        Product::factory()->create([
+            'productable_type' => $minifig->getMorphClass(),
+            'productable_id' => $minifig->id,
+            'color_id' => $color->id,
+            'stock' => 2,
+        ]);
+
+        $this->get(route('catalog.minifigs'))->assertOk();
+    }
+
+    public function test_sets_index_renders(): void
+    {
+        Set::factory()->create();
+
+        $this->get(route('sets.index'))->assertOk();
+    }
+
+    public function test_sitemap_is_public(): void
+    {
+        $this->get(route('sitemap'))
+            ->assertOk()
+            ->assertHeader('Content-Type', 'application/xml');
+    }
+
+    public function test_catalog_search_scopes_name_or_bricklink_to_the_productable(): void
+    {
+        $matching = Part::factory()->create([
+            'name' => 'Blue Plate',
+            'bricklink_id' => '3023',
+        ]);
+        $unrelated = Part::factory()->create([
+            'name' => 'Red Brick',
+            'bricklink_id' => '3001',
+        ]);
+        $color = Color::factory()->create();
+
+        $matchProduct = Product::factory()->create([
+            'productable_type' => $matching->getMorphClass(),
+            'productable_id' => $matching->id,
+            'color_id' => $color->id,
+            'stock' => 5,
+        ]);
+        Product::factory()->create([
+            'productable_type' => $unrelated->getMorphClass(),
+            'productable_id' => $unrelated->id,
+            'color_id' => $color->id,
+            'stock' => 5,
+        ]);
+
+        $this->get(route('catalog.search', ['q' => '3023']))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('shop/catalog')
+                ->has('products.data', 1)
+                ->where('products.data.0.id', $matchProduct->id));
+    }
+}

--- a/tests/Feature/Models/MinifigSearchableTest.php
+++ b/tests/Feature/Models/MinifigSearchableTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Models\Minifig;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Scout\Searchable;
+use Tests\TestCase;
+
+class MinifigSearchableTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_minifig_uses_the_searchable_trait(): void
+    {
+        $this->assertContains(Searchable::class, class_uses_recursive(Minifig::class));
+    }
+
+    public function test_to_searchable_array_includes_ids_and_name(): void
+    {
+        $minifig = Minifig::factory()->create([
+            'rebrickable_id' => 'fig-000123',
+            'bricklink_id' => 'sw0001',
+            'name' => 'Luke Skywalker',
+        ]);
+
+        $document = $minifig->toSearchableArray();
+
+        $this->assertSame((string) $minifig->id, $document['id']);
+        $this->assertSame('fig-000123', $document['rebrickable_id']);
+        $this->assertSame('sw0001', $document['bricklink_id']);
+        $this->assertSame('Luke Skywalker', $document['name']);
+    }
+
+    public function test_make_all_searchable_is_available_for_scout_import(): void
+    {
+        Minifig::factory()->count(2)->create();
+
+        // scout:import ultimately calls this static method from the Searchable trait.
+        Minifig::makeAllSearchable();
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Feature/Models/ProductSearchableTest.php
+++ b/tests/Feature/Models/ProductSearchableTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Models\Color;
+use App\Models\Minifig;
+use App\Models\Part;
+use App\Models\PartCategory;
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductSearchableTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_to_searchable_array_works_for_minifig_products(): void
+    {
+        $minifig = Minifig::factory()->create([
+            'name' => 'Luke Skywalker',
+            'bricklink_id' => 'sw0001',
+        ]);
+
+        $product = Product::factory()->create([
+            'productable_type' => $minifig->getMorphClass(),
+            'productable_id' => $minifig->id,
+            'color_id' => Color::factory(),
+            'stock' => 5,
+            'price' => 250,
+        ]);
+
+        $document = $product->toSearchableArray();
+
+        $this->assertSame((string) $product->id, $document['id']);
+        $this->assertSame('Luke Skywalker', $document['name']);
+        $this->assertSame('sw0001', $document['bricklink_id']);
+        $this->assertSame('minifig', $document['type']);
+        $this->assertSame(0, $document['category_id']);
+        $this->assertSame('', $document['category_name']);
+        $this->assertSame(5, $document['stock']);
+        $this->assertSame(250, $document['price']);
+    }
+
+    public function test_to_searchable_array_includes_part_category(): void
+    {
+        $category = PartCategory::factory()->create(['name' => 'Bricks']);
+        $part = Part::factory()->create([
+            'name' => 'Brick 2x4',
+            'bricklink_id' => '3001',
+            'part_category_id' => $category->id,
+        ]);
+
+        $product = Product::factory()->create([
+            'productable_type' => $part->getMorphClass(),
+            'productable_id' => $part->id,
+            'color_id' => Color::factory(),
+            'stock' => 10,
+            'price' => 15,
+        ]);
+
+        $document = $product->toSearchableArray();
+
+        $this->assertSame('part', $document['type']);
+        $this->assertSame($category->id, $document['category_id']);
+        $this->assertSame('Bricks', $document['category_name']);
+        $this->assertSame('Brick 2x4', $document['name']);
+        $this->assertSame('3001', $document['bricklink_id']);
+    }
+
+    public function test_make_all_searchable_using_eager_loads_part_category_only_for_parts(): void
+    {
+        $category = PartCategory::factory()->create(['name' => 'Plates']);
+        $part = Part::factory()->create([
+            'name' => 'Plate 1x2',
+            'part_category_id' => $category->id,
+        ]);
+        $minifig = Minifig::factory()->create(['name' => 'Han Solo']);
+
+        Product::factory()->create([
+            'productable_type' => $part->getMorphClass(),
+            'productable_id' => $part->id,
+            'color_id' => Color::factory(),
+        ]);
+        Product::factory()->create([
+            'productable_type' => $minifig->getMorphClass(),
+            'productable_id' => $minifig->id,
+            'color_id' => Color::factory(),
+        ]);
+
+        $products = (new Product)->makeAllSearchableUsing(Product::query())->get();
+
+        $this->assertCount(2, $products);
+
+        foreach ($products as $product) {
+            $this->assertNotEmpty($product->toSearchableArray());
+        }
+    }
+}

--- a/tests/Feature/Shop/ProductPageTest.php
+++ b/tests/Feature/Shop/ProductPageTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Shop;
+
+use App\Models\Color;
+use App\Models\Minifig;
+use App\Models\Part;
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class ProductPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_shows_a_part_product_page(): void
+    {
+        $part = Part::factory()->create([
+            'name' => 'Brick 2x4',
+            'bricklink_id' => '3001',
+        ]);
+        $product = Product::factory()->create([
+            'productable_type' => $part->getMorphClass(),
+            'productable_id' => $part->id,
+            'color_id' => Color::factory(),
+            'stock' => 5,
+            'price' => 150,
+        ]);
+
+        $this->get(route('product.show', $product))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('shop/product')
+                ->has('product')
+                ->where('product.data.id', $product->id)
+                ->where('product.data.title', 'Brick 2x4')
+                ->where('product.data.type', 'part'));
+    }
+
+    public function test_it_shows_a_minifig_product_page_without_part_colors_relationship_error(): void
+    {
+        $minifig = Minifig::factory()->create([
+            'name' => 'Luke Skywalker',
+            'bricklink_id' => 'sw0001',
+        ]);
+        $product = Product::factory()->create([
+            'productable_type' => $minifig->getMorphClass(),
+            'productable_id' => $minifig->id,
+            'color_id' => Color::factory(),
+            'stock' => 3,
+            'price' => 1250,
+        ]);
+
+        $this->get(route('product.show', $product))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('shop/product')
+                ->has('product')
+                ->where('product.data.id', $product->id)
+                ->where('product.data.title', 'Luke Skywalker')
+                ->where('product.data.type', 'minifig')
+                ->where('product.data.lego_number', 'sw0001'));
+    }
+}


### PR DESCRIPTION
## Summary
- Catalog controllers for parts/minifigs/search and sets index
- Shared `ProductListingQuery` eager-load strategy
- API search stock filtering and minifig separation
- Product page suggestions (in stock only) + Scout after_commit

Depends on #5 (base branch `feature/5-bricqer-pipeline`).

Closes #6

## Test plan
- [x] Catalog / product / search feature tests
- [ ] CI green after stack merges